### PR TITLE
Experiment2 for Unexpected end of ZLIB input stream

### DIFF
--- a/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/JsonDumpFileProcessor.java
+++ b/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/JsonDumpFileProcessor.java
@@ -154,6 +154,7 @@ public class JsonDumpFileProcessor implements MwDumpFileProcessor {
 				inputStream));
 
 		String line = br.readLine();
+		br.close();
 		if (line == null) { // can happen if iterator already has consumed all
 							// the stream
 			return;
@@ -185,6 +186,5 @@ public class JsonDumpFileProcessor implements MwDumpFileProcessor {
 
 			line = br.readLine();
 		}
-		br.close();
 	}
 }


### PR DESCRIPTION
Since the error is at org.wikidata.wdtk.dumpfiles.JsonDumpFileProcessor.processDumpFileContentsRecovery(JsonDumpFileProcessor.java:156), move br.close() to line 156.